### PR TITLE
Added support for Qanary component logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+mlruns/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ import uvicorn
 
 from qanary_helpers.registration import Registration
 from qanary_helpers.registrator import Registrator
-from qanary_helpers.qanary_queries import insert_into_triplestore, get_text_question_in_graph, query_triplestore
+from qanary_helpers.qanary_queries import insert_into_triplestore, get_text_question_in_graph
+from qanary_helpers.logging import MLFlowLogger
 
 if not os.getenv("PRODUCTION"):
     from dotenv import load_dotenv
@@ -105,6 +106,15 @@ async def qanary_service(request: Request):
 
     insert_into_triplestore(triplestore_endpoint_url,
                             SPARQLquery)  # inserting new data to the triplestore
+    
+    # Initializing logging with MLFlow
+    # TODO: Update connection settings, if necessary
+    logger = MLFlowLogger()
+    
+    # logging the annotation of the component
+    # TODO: replace "sparql_query" with your annotation data
+    logger.log_annotation(SERVICE_NAME_COMPONENT, question_text, '', sparql_query, triplestore_ingraph_uuid)
+    
     # End TODO
 
     return JSONResponse(content=request_json)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ async def qanary_service(request: Request):
     
     # logging the annotation of the component
     # TODO: replace "sparql_query" with your annotation data
-    logger.log_annotation(SERVICE_NAME_COMPONENT, question_text, '', sparql_query, triplestore_ingraph_uuid)
+    logger.log_annotation(SERVICE_NAME_COMPONENT, question_text, sparql_query, triplestore_ingraph_uuid)
     
     # End TODO
 

--- a/qanary_helpers/logging/__init__.py
+++ b/qanary_helpers/logging/__init__.py
@@ -1,0 +1,2 @@
+from .component_logging import MLFlowLogger, QanaryComponentLogger
+from .config import mlflow_host, mlflow_port, mlflow_port_artifact, ssl, sftp

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -13,8 +13,8 @@ class QanaryComponentLogger(ABC):
     Class providing a Logging interface for Qanary components
     """
     @abstractmethod
-    def log_train_results(self, docker_image_tag: str, dataset: str, hyperparameters: dict[str, Any],
-                          metrics: dict[str, float], component_name: str, component_type: str, hardware: str,
+    def log_train_results(self, docker_image_tag: str, dataset: str, hyperparameters: Dict[str, Any],
+                          metrics: Dict[str, float], component_name: str, component_type: str, hardware: str,
                           model: str, time: float) -> Any:
         """
         Logging train results of the Qanary component
@@ -75,8 +75,8 @@ class MLFlowLogger(QanaryComponentLogger):
         if use_sftp:
             load_ssh_host_key(ssh_host, ssh_port)
 
-    def log_train_results(self, docker_image_tag: str, dataset: str, hyperparameters: dict[str, Any],
-                          metrics: dict[str, float], component_name: str, component_type: str, hardware: str,
+    def log_train_results(self, docker_image_tag: str, dataset: str, hyperparameters: Dict[str, Any],
+                          metrics: Dict[str, float], component_name: str, component_type: str, hardware: str,
                           model: str, time: float) -> Any:
         mlflow.set_experiment('AutoML Model Training')
 
@@ -112,7 +112,7 @@ class MLFlowLogger(QanaryComponentLogger):
 
             return run.info.run_id
 
-    def log_test_results(self, questions: list[dict[str, Any]]) -> Any:
+    def log_test_results(self, questions: List[Dict[str, Any]]) -> Any:
         mlflow.set_experiment('AutoML Model Testing')
 
         run_ids = []

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -1,0 +1,141 @@
+import os
+import mlflow
+from .config import mlflow_uri, test_params, sftp, mlflow_host, mlflow_port_artifact
+from abc import ABC, abstractmethod
+from typing import Any
+from uuid import uuid4
+from shutil import rmtree
+from .get_ssh_key import load_ssh_host_key
+
+
+class QanaryComponentLogger(ABC):
+    """
+    Class providing a Logging interface for Qanary components
+    """
+    @abstractmethod
+    def log_train_results(self, docker_image_tag: str, dataset: str, hyperparameters: dict[str, Any],
+                          metrics: dict[str, float], component_name: str, component_type: str, hardware: str,
+                          model: str, time: float) -> Any:
+        """
+        Logging train results of the Qanary component
+
+        :param docker_image_tag: used docker image and tag
+        :param dataset: train data as text file content
+        :param hyperparameters: dictionary of [hyperparameter_name, value] pairs
+        :param metrics: dictionary of [metric_name, value] pairs
+        :param component_name: name of the Qanary component
+        :param component_type: type of the Qanary component
+        :param hardware: used hardware for training
+        :param model: name of the used model
+        :param time: runtime of the training
+        :return: Identifier for the logged train results
+        """
+
+    @abstractmethod
+    def log_test_results(self, questions: list[dict[str, str | float]]) -> Any:
+        """
+        Logging test results for all test questions. Each question dictionary requires the keys
+        "input", "true_target", "predicted_target", "docker_image_tag" and "runtime"
+
+        :param questions: list of parameters that have to be logged for each question
+        :return: Identifier for the logged test results
+        """
+
+    @abstractmethod
+    def log_annotation(self, docker_image_tag: str, question: str, true_target: str,
+                       predicted_target: str, qanary_graph_id: str) -> Any:
+        """
+        Logging the data of the created annotation of a Qanary component
+
+        :param docker_image_tag: used docker image and tag
+        :param question: question as string data
+        :param true_target: expected true target
+        :param predicted_target: target predicted by the component
+        :param qanary_graph_id: Qanary Graph ID of the annotation
+        :return: Identifier for the logged annotation data
+        """
+
+
+class MLFlowLogger(QanaryComponentLogger):
+    """
+    Class providing a Logging service for Qanary components with MLFlow
+    """
+    def __init__(self, uri=mlflow_uri, use_sftp=sftp, ssh_host=mlflow_host, ssh_port=mlflow_port_artifact):
+        """
+        Initializes a Logger for Qanary components with MLFlow. Default setup connects to http://localhost:5000 with
+        local artifact storage.
+
+        :param uri: MLFlow tracking URI
+        :param use_sftp: True, if MLFlow uses SFTP artifact storage, else False
+        :param ssh_host: SFTP hostname
+        :param ssh_port: SSH port of SFTP storage host
+        """
+        mlflow.set_tracking_uri(uri)
+
+        if use_sftp:
+            load_ssh_host_key(ssh_host, ssh_port)
+
+    def log_train_results(self, docker_image_tag: str, dataset: str, hyperparameters: dict[str, Any],
+                          metrics: dict[str, float], component_name: str, component_type: str, hardware: str,
+                          model: str, time: float) -> Any:
+        mlflow.set_experiment('AutoML Model Training')
+
+        temp_path = str(uuid4())
+        os.mkdir(temp_path)
+
+        temp_dataset = f'{temp_path}/dataset.csv'
+
+        # store dataset to filesystem
+        with open(temp_dataset, 'w') as f:
+            f.write(dataset)
+
+        with mlflow.start_run() as run:
+            # Log train parameters and model results
+            try:
+                mlflow.log_param('docker_image_tag', docker_image_tag)
+                mlflow.log_artifact(temp_dataset, 'datasets')
+
+                for parameter in hyperparameters:
+                    mlflow.log_param(parameter, hyperparameters[parameter])
+
+                for metric in metrics:
+                    mlflow.log_metric(metric, metrics[metric])
+
+                mlflow.log_param('component_name', component_name)
+                mlflow.log_param('component_type', component_type)
+                mlflow.log_param('hardware', hardware)
+                mlflow.log_param('model', model)
+                mlflow.log_param('time', time)
+            # delete temp dataset file
+            finally:
+                rmtree(temp_path)
+
+            return run.info.run_id
+
+    def log_test_results(self, questions: list[dict[str, Any]]) -> Any:
+        mlflow.set_experiment('AutoML Model Testing')
+
+        run_ids = []
+
+        for question in questions:
+            with mlflow.start_run() as run:
+                # log all provided data as parameters
+                for test_param in test_params:
+                    mlflow.log_param(test_param, question[test_param])
+
+                run_ids.append(run.info.run_id)
+
+        return run_ids
+
+    def log_annotation(self, docker_image_tag: str, question: str, true_target: str, predicted_target: str,
+                       qanary_graph_id: str) -> Any:
+        mlflow.set_experiment('AutoML Component Annotations')
+
+        with mlflow.start_run() as run:
+            mlflow.log_param('docker_image_tag', docker_image_tag)
+            mlflow.log_param('input', question)
+            mlflow.log_param('true_target', true_target)
+            mlflow.log_param('predicted_target', predicted_target)
+            mlflow.log_param('qanary_graph_id', qanary_graph_id)
+
+            return run.info.run_id

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -39,7 +39,7 @@ class QanaryComponentLogger(ABC):
     def log_test_results(self, questions: List[Dict[str, Union[str, float]]]) -> Any:
         """
         Logging test results for all test questions. Each question dictionary requires the keys
-        "input", "true_target", "predicted_target", "docker_image_tag" and "runtime"
+        "input", "true_target", "predicted_target", "model_uuid" and "runtime"
 
         :param questions: list of parameters that have to be logged for each question
         :return: Identifier for the logged test results
@@ -85,7 +85,7 @@ class MLFlowLogger(QanaryComponentLogger):
         temp_path = str(uuid4())
         os.mkdir(temp_path)
 
-        temp_dataset = f'{temp_path}/dataset.csv'
+        temp_dataset = f'{temp_path}/dataset.txt'
 
         # store dataset to filesystem
         with open(temp_dataset, 'w') as f:

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -17,7 +17,7 @@ class QanaryComponentLogger(ABC):
     """
     @abstractmethod
     def log_train_results(self, model_uuid: str, dataset: str, hyperparameters: Dict[str, Any], config: str,
-                          metrics: Dict[str, float], component_name: str, component_type: str, hardware: str,
+                          metrics: Dict[str, Any], component_name: str, component_type: str, hardware: str,
                           model: str, time: float) -> Any:
         """
         Logging train results of the Qanary component
@@ -100,8 +100,7 @@ class MLFlowLogger(QanaryComponentLogger):
                 for parameter in hyperparameters:
                     mlflow.log_param(parameter, hyperparameters[parameter])
 
-                for metric in metrics:
-                    mlflow.log_metric(metric, metrics[metric])
+                mlflow.log_dict(metrics, 'model_metrics.json')
 
                 mlflow.log_param('config', config)
                 mlflow.log_param('component_name', component_name)

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -2,7 +2,7 @@ import os
 import mlflow
 from .config import mlflow_uri, test_params, sftp, mlflow_host, mlflow_port_artifact
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Dict, List, Union
 from uuid import uuid4
 from shutil import rmtree
 from .get_ssh_key import load_ssh_host_key
@@ -32,7 +32,7 @@ class QanaryComponentLogger(ABC):
         """
 
     @abstractmethod
-    def log_test_results(self, questions: list[dict[str, str | float]]) -> Any:
+    def log_test_results(self, questions: List[Dict[str, Union[str, float]]]) -> Any:
         """
         Logging test results for all test questions. Each question dictionary requires the keys
         "input", "true_target", "predicted_target", "docker_image_tag" and "runtime"

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -6,6 +6,9 @@ from typing import Any, Dict, List, Union
 from uuid import uuid4
 from shutil import rmtree
 from .get_ssh_key import load_ssh_host_key
+import logging
+
+logging.getLogger("paramiko").setLevel(logging.WARNING)
 
 
 class QanaryComponentLogger(ABC):

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -16,7 +16,7 @@ class QanaryComponentLogger(ABC):
     Class providing a Logging interface for Qanary components
     """
     @abstractmethod
-    def log_train_results(self, model_uuid: str, dataset: str, hyperparameters: Dict[str, Any], config: str,
+    def log_train_results(self, model_uuid: str, dataset: str, hyperparameters: Dict[str, Any], config: Dict[str, Any],
                           metrics: Dict[str, Any], component_name: str, component_type: str, hardware: str,
                           model: str, time: float) -> Any:
         """
@@ -25,7 +25,7 @@ class QanaryComponentLogger(ABC):
         :param model_uuid: UUID of the trained model
         :param dataset: train data as text file content
         :param hyperparameters: dictionary of [hyperparameter_name, value] pairs
-        :param config: model config as string
+        :param config: model config as dictionary
         :param metrics: dictionary of [metric_name, value] pairs
         :param component_name: name of the Qanary component
         :param component_type: type of the Qanary component
@@ -77,7 +77,7 @@ class MLFlowLogger(QanaryComponentLogger):
         if use_sftp:
             load_ssh_host_key(ssh_host, ssh_port)
 
-    def log_train_results(self, model_uuid: str, dataset: str, hyperparameters: Dict[str, Any], config: str,
+    def log_train_results(self, model_uuid: str, dataset: str, hyperparameters: Dict[str, Any], config: Dict[str, Any],
                           metrics: Dict[str, float], component_name: str, component_type: str, hardware: str,
                           model: str, time: float) -> Any:
         mlflow.set_experiment('AutoML Model Training')

--- a/qanary_helpers/logging/component_logging.py
+++ b/qanary_helpers/logging/component_logging.py
@@ -101,8 +101,7 @@ class MLFlowLogger(QanaryComponentLogger):
                     mlflow.log_param(parameter, hyperparameters[parameter])
 
                 mlflow.log_dict(metrics, 'model_metrics.json')
-
-                mlflow.log_param('config', config)
+                mlflow.log_dict(config, 'config.json')
                 mlflow.log_param('component_name', component_name)
                 mlflow.log_param('component_type', component_type)
                 mlflow.log_param('hardware', hardware)

--- a/qanary_helpers/logging/config.py
+++ b/qanary_helpers/logging/config.py
@@ -1,0 +1,11 @@
+mlflow_host = 'localhost'
+mlflow_port = 5000
+mlflow_port_artifact = None
+
+ssl = False
+
+sftp = False
+
+test_params = ['input', 'true_target', 'predicted_target', 'docker_image_tag', 'runtime']
+
+mlflow_uri = f'http{"s" if ssl else ""}://{mlflow_host}:{mlflow_port}'

--- a/qanary_helpers/logging/config.py
+++ b/qanary_helpers/logging/config.py
@@ -6,6 +6,7 @@ ssl = False
 
 sftp = False
 
-test_params = ['input', 'true_target', 'predicted_target', 'docker_image_tag', 'runtime']
+test_params = ['input', 'model_uuid', 'runtime']
+test_dicts = ['true_target', 'predicted_target']
 
 mlflow_uri = f'http{"s" if ssl else ""}://{mlflow_host}:{mlflow_port}'

--- a/qanary_helpers/logging/get_ssh_key.py
+++ b/qanary_helpers/logging/get_ssh_key.py
@@ -1,0 +1,55 @@
+import socket
+import paramiko
+from pathlib import Path
+import os
+
+
+def load_ssh_host_key(host, ssh_port):
+    """
+    Load the SSH host key of a remote server and stores it as a known host
+    """
+    with socket.socket() as sock:
+        # init connection
+        sock.connect((host, int(ssh_port)))
+
+        # establish connection
+        trans = paramiko.transport.Transport(sock)
+        trans.start_client()
+
+        # load host key
+        key = trans.get_remote_server_key().get_base64()
+
+        trans.close()
+
+    # home directory of executing user
+    home_dir = Path.home()
+
+    # SSH host key entry
+    host_key = f'{host} ssh-ed25519 {key}'
+
+    # no SSH config for current user
+    if not os.path.exists(f'{home_dir}/.ssh'):
+        os.mkdir(f'{home_dir}/.ssh')
+
+        # create new known hosts file and store key
+        with open(f'{home_dir}/.ssh/known_hosts', 'w') as f:
+            f.write(host_key)
+    # SSH config exists
+    else:
+        # loading existing config
+        with open(f'{home_dir}/.ssh/known_hosts') as f:
+            hosts = f.read()
+
+            if not hosts.endswith('\n'):
+                hosts += '\n'
+
+        # SSH host key not known
+        if host_key not in hosts:
+            # add key to config file
+            with open(f'{home_dir}/.ssh/known_hosts', 'w') as f:
+                f.write(hosts)
+                f.write(host_key)
+
+
+if __name__ == '__main__':
+    load_ssh_host_key()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 flask
-setuptools==49.6.0
+setuptools
 requests
-SPARQLWrapper==1.8.5
+SPARQLWrapper
+mlflow
+pysftp

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def read_requirements():
 
 setuptools.setup(
     name="qanary-helpers",
-    version="0.1.3",
+    version="0.2.0",
     author="Andreas Both, Aleksandr Perevalov",
     author_email="andreas.both@htwk-leipzig.de, aleksandr.perevalov@hs-anhalt.de",
     description="A package that helps to build components for the Qanary Framework",

--- a/tests/logging_test_mlflow_instance/Dockerfile
+++ b/tests/logging_test_mlflow_instance/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:latest
+ARG MLFLOW_PORT_ARTIFACT
+ARG MLFLOW_USERNAME
+ARG MLFLOW_PASSWORD
+RUN apt update && apt install -y openssh-server
+RUN echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
+RUN echo "Port ${MLFLOW_PORT_ARTIFACT}" >> /etc/ssh/sshd_config
+RUN useradd -d /home/mlflow -s /bin/bash -p "$(openssl passwd -1 ${MLFLOW_PASSWORD})" ${MLFLOW_USERNAME}
+RUN pip install mlflow pysftp
+RUN service ssh start
+COPY start.sh /start.sh
+ENTRYPOINT ["/start.sh"]

--- a/tests/logging_test_mlflow_instance/docker-compose.yml
+++ b/tests/logging_test_mlflow_instance/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.5'
+services:
+  mlflow:
+    build:
+      context: .
+      args:
+        MLFLOW_PORT_ARTIFACT: $MLFLOW_PORT_ARTIFACT
+        MLFLOW_USERNAME: $MLFLOW_USERNAME
+        MLFLOW_PASSWORD: $MLFLOW_PASSWORD
+    environment:
+      - MLFLOW_HOST=$MLFLOW_HOST
+      - MLFLOW_PORT=$MLFLOW_PORT
+      - MLFLOW_PORT_ARTIFACT=$MLFLOW_PORT_ARTIFACT
+      - MLFLOW_USERNAME=$MLFLOW_USERNAME
+      - MLFLOW_PASSWORD=$MLFLOW_PASSWORD
+    ports:
+      - "$MLFLOW_PORT:5000"
+      - "$MLFLOW_PORT_ARTIFACT:$MLFLOW_PORT_ARTIFACT"
+    volumes:
+      - artifacts:/home/mlflow
+volumes:
+  artifacts: {}

--- a/tests/logging_test_mlflow_instance/start.sh
+++ b/tests/logging_test_mlflow_instance/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+chown -R mlflow /home/mlflow
+
+if [ ! -d "$HOME/.ssh" ]; then
+  mkdir ~/.ssh
+fi
+
+/usr/sbin/sshd -D &
+sleep 1
+ssh-keyscan -p ${MLFLOW_PORT_ARTIFACT} localhost | sed -e 's/\[//g' -e 's/\]:[0-9]\+//g' > ~/.ssh/known_hosts
+
+mlflow server --host 0.0.0.0 --default-artifact-root sftp://${MLFLOW_USERNAME}:${MLFLOW_PASSWORD}@${MLFLOW_HOST}:${MLFLOW_PORT_ARTIFACT}/home/mlflow/artifacts --serve-artifacts

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -31,11 +31,12 @@ class MyTestCase(unittest.TestCase):
 
         self.assertEqual(dataset, artifact_data)
 
-        self.assertEqual(2, len(run.data.metrics))
+        metrics = mlflow.artifacts.load_dict(f'{run.info.artifact_uri}/model_metrics.json')
+        self.assertEqual(2, len(metrics))
+
         self.assertEqual(9, len(run.data.params))
         self.assertEqual('test:latest', run.data.params['model_uuid'])
         self.assertEqual('CPU', run.data.params['hardware'])
-        self.assertEqual(0.9, run.data.metrics['acc'])
 
     def test_test_logging(self):
         run_ids = self.logger.log_test_results([

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,74 @@
+import unittest
+from qanary_helpers.logging import MLFlowLogger
+import mlflow
+import os
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.logger = MLFlowLogger(os.environ['MLFLOW_URI'], True, os.environ['MLFLOW_HOST'],
+                                   os.environ['MLFLOW_PORT_ARTIFACT'])
+        with open('dataset.csv', 'w') as f:
+            f.write('test1,test2\n0,1\n2,3')
+
+    def tearDown(self) -> None:
+        os.remove('dataset.csv')
+
+    def test_train_logging(self):
+        with open('dataset.csv') as f:
+            dataset = f.read()
+
+        run_id = self.logger.log_train_results('test:latest', dataset, {'C': 0.5, 'balance': 'weighted'},
+                                               {'acc': 0.9, 'F1': 0.7}, 'basic_component', 'NED', 'CPU', 'SVM', 17.4597)
+
+        run = mlflow.get_run(run_id)
+
+        artifact = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path='datasets/dataset.csv')
+
+        with open(artifact) as f:
+            artifact_data = f.read()
+
+        self.assertEqual(dataset, artifact_data)
+
+        self.assertEqual(2, len(run.data.metrics))
+        self.assertEqual(8, len(run.data.params))
+        self.assertEqual('test:latest', run.data.params['docker_image_tag'])
+        self.assertEqual('CPU', run.data.params['hardware'])
+        self.assertEqual(0.9, run.data.metrics['acc'])
+
+    def test_test_logging(self):
+        run_ids = self.logger.log_test_results([
+            {
+                'input': 'How much is the fish?',
+                'true_target': 'Scooter',
+                'predicted_target': 'Scouter',
+                'docker_image_tag': 'MusicianAnnotator:latest',
+                'runtime': 17.8901
+            },
+            {
+                'input': 'Who made Thriller?',
+                'true_target': 'Michael Jackson',
+                'predicted_target': 'Michael Jackson',
+                'docker_image_tag': 'MusicianAnnotator:latest',
+                'runtime': 7.321
+            }
+        ])
+
+        self.assertEqual(2, len(run_ids))
+
+        run = mlflow.get_run(run_ids[0])
+
+        self.assertEqual(5, len(run.data.params))
+        self.assertEqual('Scooter', run.data.params['true_target'])
+
+    def test_annotation_logging(self):
+        run_id = self.logger.log_annotation('MusicianAnnotator:latest', 'How much is the fish?', 'Scooter', 'Scouter',
+                                            'abc-def0123456789')
+
+        run = mlflow.get_run(run_id)
+
+        self.assertEqual(5, len(run.data.params))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,7 +19,7 @@ class MyTestCase(unittest.TestCase):
             dataset = f.read()
 
         run_id = self.logger.log_train_results('test:latest', dataset, {'C': 0.5, 'balance': 'weighted'},
-                                               'special config', {'acc': 0.9, 'F1': 0.7}, 'basic_component', 'NED',
+                                               {'param1': 3}, {'acc': 0.9, 'F1': 0.7}, 'basic_component', 'NED',
                                                'CPU', 'SVM', 17.4597)
 
         run = mlflow.get_run(run_id)
@@ -34,7 +34,10 @@ class MyTestCase(unittest.TestCase):
         metrics = mlflow.artifacts.load_dict(f'{run.info.artifact_uri}/model_metrics.json')
         self.assertEqual(2, len(metrics))
 
-        self.assertEqual(9, len(run.data.params))
+        config = mlflow.artifacts.load_dict(f'{run.info.artifact_uri}/config.json')
+        self.assertEqual(1, len(config))
+
+        self.assertEqual(8, len(run.data.params))
         self.assertEqual('test:latest', run.data.params['model_uuid'])
         self.assertEqual('CPU', run.data.params['hardware'])
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,7 +19,8 @@ class MyTestCase(unittest.TestCase):
             dataset = f.read()
 
         run_id = self.logger.log_train_results('test:latest', dataset, {'C': 0.5, 'balance': 'weighted'},
-                                               {'acc': 0.9, 'F1': 0.7}, 'basic_component', 'NED', 'CPU', 'SVM', 17.4597)
+                                               'special config', {'acc': 0.9, 'F1': 0.7}, 'basic_component', 'NED',
+                                               'CPU', 'SVM', 17.4597)
 
         run = mlflow.get_run(run_id)
 
@@ -31,8 +32,8 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(dataset, artifact_data)
 
         self.assertEqual(2, len(run.data.metrics))
-        self.assertEqual(8, len(run.data.params))
-        self.assertEqual('test:latest', run.data.params['docker_image_tag'])
+        self.assertEqual(9, len(run.data.params))
+        self.assertEqual('test:latest', run.data.params['model_uuid'])
         self.assertEqual('CPU', run.data.params['hardware'])
         self.assertEqual(0.9, run.data.metrics['acc'])
 
@@ -40,16 +41,16 @@ class MyTestCase(unittest.TestCase):
         run_ids = self.logger.log_test_results([
             {
                 'input': 'How much is the fish?',
-                'true_target': 'Scooter',
-                'predicted_target': 'Scouter',
-                'docker_image_tag': 'MusicianAnnotator:latest',
+                'true_target': {'value': 'Scooter'},
+                'predicted_target': {'value': 'Scouter'},
+                'model_uuid': 'MusicianAnnotator:latest',
                 'runtime': 17.8901
             },
             {
                 'input': 'Who made Thriller?',
-                'true_target': 'Michael Jackson',
-                'predicted_target': 'Michael Jackson',
-                'docker_image_tag': 'MusicianAnnotator:latest',
+                'true_target': {'value': 'Michael Jackson'},
+                'predicted_target': {'value': 'Michael Jackson'},
+                'model_uuid': 'MusicianAnnotator:latest',
                 'runtime': 7.321
             }
         ])
@@ -58,16 +59,19 @@ class MyTestCase(unittest.TestCase):
 
         run = mlflow.get_run(run_ids[0])
 
-        self.assertEqual(5, len(run.data.params))
-        self.assertEqual('Scooter', run.data.params['true_target'])
+        artifact_uri = run.info.artifact_uri
+        load_dict = mlflow.artifacts.load_dict(f'{artifact_uri}/true_target.json')
+
+        self.assertEqual(3, len(run.data.params))
+        self.assertEqual({'value': 'Scooter'}, load_dict)
 
     def test_annotation_logging(self):
-        run_id = self.logger.log_annotation('MusicianAnnotator:latest', 'How much is the fish?', 'Scooter', 'Scouter',
+        run_id = self.logger.log_annotation('MusicianAnnotator:latest', 'How much is the fish?', 'Scooter',
                                             'abc-def0123456789')
 
         run = mlflow.get_run(run_id)
 
-        self.assertEqual(5, len(run.data.params))
+        self.assertEqual(4, len(run.data.params))
 
 
 if __name__ == '__main__':

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -24,7 +24,7 @@ class MyTestCase(unittest.TestCase):
 
         run = mlflow.get_run(run_id)
 
-        artifact = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path='datasets/dataset.csv')
+        artifact = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path='datasets/dataset.txt')
 
         with open(artifact) as f:
             artifact_data = f.read()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,16 +2,20 @@ import unittest
 from qanary_helpers.logging import MLFlowLogger
 import mlflow
 import os
+from subprocess import Popen
 
 
 class MyTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self.logger = MLFlowLogger(os.environ['MLFLOW_URI'], True, os.environ['MLFLOW_HOST'],
-                                   os.environ['MLFLOW_PORT_ARTIFACT'])
+        self.mlflow_server = Popen(['mlflow', 'server', '--host', '0.0.0.0'])
+
+        self.logger = MLFlowLogger()
         with open('dataset.csv', 'w') as f:
             f.write('test1,test2\n0,1\n2,3')
 
     def tearDown(self) -> None:
+        self.mlflow_server.kill()
+        self.mlflow_server.wait()
         os.remove('dataset.csv')
 
     def test_train_logging(self):


### PR DESCRIPTION
Providing a new package "logging" with an abstract class "QanaryComponentLogger", which can be used to implement custom logging mechanisms. By default, the "MLFlowLogger" class is provided allowing Qanary components to log their results to a MLFlow instance.

## Test
To test the logging run the `test_logging.py` script. Therefore, a Docker Image with a configured MLFlow server is provided in the directory `tests/logging_test_mlflow_instance`. Before starting the Docker Container it is required to set the following environment variables for the Docker-Compose file *and* the host system.

```bash
MLFLOW_URI=http://localhost:5000
MLFLOW_HOST=localhost
MLFLOW_PORT=5000
MLFLOW_PORT_ARTIFACT=5001
MLFLOW_USERNAME=mlflow
MLFLOW_PASSWORD=mlflow
```