### PR TITLE
change to overcome Stardog Java parsing error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import setuptools
 import os
 
-__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+__location__ = os.path.realpath(os.path.join(
+    os.getcwd(), os.path.dirname(__file__)))
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -20,10 +21,10 @@ def read_requirements():
 
 setuptools.setup(
     name="qanary-helpers",
-    version="0.2.0",
+    version="0.2.1",
     author="Andreas Both, Aleksandr Perevalov",
     author_email="andreas.both@htwk-leipzig.de, aleksandr.perevalov@hs-anhalt.de",
-    description="A package that helps to build components for the Qanary Framework",
+    description="A package that helps to build Python components for the Qanary Question Answering framework",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Perevalov/qanary_helpers",
@@ -40,4 +41,3 @@ setuptools.setup(
     python_requires='>=3.7',
     **read_requirements()
 )
-


### PR DESCRIPTION
the error occurs in com.complexible.stardog » client-http » 8.1.1 while parsing a SPARQL query containing the `CONCAT` method.

example: `SELECT (CONCAT("a","b") AS ?res) {}`