### PR TITLE
Pin ruff to 0.15.22 so CI stops breaking on linter releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - run: pip install ruff
+      - run: pip install ruff==0.15.22
       - run: ruff check qanary_helpers/ tests/
 
   test:


### PR DESCRIPTION
## What broke

The lint step installed **ruff unpinned**:

```yaml
- run: pip install ruff
```

so every CI run picked up whatever ruff had just been released. **ruff 0.16.0 (2026-07-23)** promoted several rules into its default set, and this repository went red with **no change of its own**.

## How widespread

Every repository in the org that runs a blocking `ruff check` is affected — **15 of them**. Verified by running each repo's own CI lint command under both versions:

| ruff | result |
|---|---|
| `0.15.22` (2026-07-16) | clean |
| `0.16.0` (2026-07-23) | fails |

Four repositories had already gone red; the rest were waiting for their next push.

## The fix

Pin ruff, so the lint result is reproducible:

```yaml
- run: pip install ruff==0.15.22
```

Dependabot already watches this repository, so the 0.16.0 upgrade will now arrive as its own reviewable PR — together with the code changes the new rules ask for — instead of landing unannounced in an unrelated dependency bump.

## Why not just fix the new findings instead

That is the right *follow-up*, but it should be a deliberate change: across the org the new rules produce several hundred findings (mostly `LOG015`, `I001`, `PLW1510`). Doing it under time pressure, in a PR that is nominally about something else, is how the lint gate loses its meaning. Pin first, upgrade on purpose.
